### PR TITLE
feat(database): add findApplicationByApplicationID & some minor refactoring

### DIFF
--- a/integration/ApplicationDAO.js
+++ b/integration/ApplicationDAO.js
@@ -1,9 +1,9 @@
-require('dotenv').config({path: `${process.cwd()}/../.env`});
-const { initModels } = require('../model/init-models');
-const cls = require('cls-hooked');
+require('dotenv').config({path: `${process.cwd()}/../.env`})
+const { initModels } = require('../model/init-models')
+const cls = require('cls-hooked')
 
 const databaseConfigPath = './config/database.js'
-const Sequelize = require ('sequelize');
+const Sequelize = require ('sequelize')
 
 
 /* 
@@ -14,19 +14,15 @@ class ApplicationDAO{
 
 /** 
  * Initializes the database based on the configurered sequelize instance from database.js
- * @param {string} env is used to initialize the testing database by having "test" as paramater
- * otherwise it defaults to the "regular" database
  */
-    constructor(env){
-        const name = cls.createNamespace('iv1201-db');
-        Sequelize.useCLS(name);
-
-        env = process.env.NODE_ENV || "development";
+    constructor(){
+        const name = cls.createNamespace('iv1201-db')
+        Sequelize.useCLS(name)
 
         this.database = require(databaseConfigPath)
-        const models = initModels(this.database);
-        this.person = models.person;
-        this.application = models.application;
+        const models = initModels(this.database)
+        this.person = models.person
+        this.application = models.application
     }
 
      /**
@@ -35,7 +31,7 @@ class ApplicationDAO{
      * to directly interact with the database object through the constructor.
      */
     getDatabase(){
-        return this.database;
+        return this.database
     }
 
    /**
@@ -52,7 +48,7 @@ class ApplicationDAO{
                 person_id : personID,
                 application_status : status,
                 })
-            return application;
+            return application
         }catch(error){
             console.debug("Couldn't create application" + error)
         }
@@ -64,19 +60,19 @@ class ApplicationDAO{
      * @param {int} personID: used to match an application in the system with the given personID
      * @param {bool} status: used to update the status of the application that was matched with the ID
      * TRUE:accepted, FALSE: rejected, NULL:unhandled
-     * @returns said application
+     * @returns the number of rows that were updated.
      */
     async handleApplicationByPersonId(personID, status){
         try{
             const application = await this.application.update({application_status : status},
                 {where: {person_id :personID}}
             )
-            return application;
+            return application
         }catch(error){console.debug("couldn't update application " + error)}
     }
 
     /**
-     * Method used to delete an application based on applicaiton ID
+     * Method used to delete an application based on application ID
      * 
      * @param {int} applicationID: used to specify which application to delete
      */
@@ -90,7 +86,7 @@ class ApplicationDAO{
     }
 
     /**
-     * Methos used to return the status of all applications, as well as 
+     * Method used to return the status of all applications, as well as 
      * the applicants' names 
      * 
      * @returns a JSON containing a list of all the applicants names, and their application status
@@ -104,9 +100,26 @@ class ApplicationDAO{
                   as:"person",
                   attributes: ['name', 'surname'] // Columns from the person table
                 }]})
-            return people;
+            return people 
         }catch(error){
             console.debug("couldn't show all applications " + error)
+        }
+    }
+
+    /**
+     * Method used to find an application based on application ID in the database.
+     * 
+     * @param {int} applicationID used to match with an existing application_id in the database
+     * @returns a JSON with the selected row in the application table, 
+     * containing person_id, application_id and application_status
+     */
+    async findApplicationByApplicationId(applicationID){
+        try{
+            const application = this.application.findAll({
+                where:{application_id :applicationID}})
+            return application
+        }catch(error){
+            console.debug("findApplicationByApplicationId couldn't find application " + error)
         }
     }
 
@@ -118,7 +131,7 @@ class ApplicationDAO{
         try{
             const users = await this.person.findAll({
                 where: { role_id: 2 }
-              });
+              })
 
             for (const user of users) {
                 await this.application.create({
@@ -134,7 +147,7 @@ class ApplicationDAO{
      * A helper method used to remove all data in the application table
      */
     async deleteAllApplicationData(){
-        await this.application.destroy({truncate: true, cascade: true });
+        await this.application.destroy({truncate: true, cascade: true })
     }
 
     /** WIP 
@@ -150,4 +163,4 @@ class ApplicationDAO{
 
 
 }
-module.exports = ApplicationDAO;
+module.exports = ApplicationDAO

--- a/integration/ApplicationDAO.js
+++ b/integration/ApplicationDAO.js
@@ -40,7 +40,7 @@ class ApplicationDAO{
     * @param {int} personID: is used to match the application with a person 
     * @param {bool} status: is used to determine the status of the application
     * TRUE:accepted, FALSE: rejected, NULL:unhandled
-    * @returns a json with the application
+    * @returns a JSON with the application
     */
     async createApplication(personID, status){
         try{
@@ -60,14 +60,17 @@ class ApplicationDAO{
      * @param {int} personID: used to match an application in the system with the given personID
      * @param {bool} status: used to update the status of the application that was matched with the ID
      * TRUE:accepted, FALSE: rejected, NULL:unhandled
-     * @returns the number of rows that were updated.
+     * @returns a JSON of the updated row in the application table. This is stored in the 1st index
+     * which is why we return only that
      */
     async handleApplicationByPersonId(personID, status){
         try{
             const application = await this.application.update({application_status : status},
-                {where: {person_id :personID}}
+                {where: {person_id :personID},
+                returning:true      //used to return the updated row
+                }
             )
-            return application
+            return application[1]   
         }catch(error){console.debug("couldn't update application " + error)}
     }
 

--- a/integration/ApplicationDAO.js
+++ b/integration/ApplicationDAO.js
@@ -115,7 +115,7 @@ class ApplicationDAO{
      */
     async findApplicationByApplicationId(applicationID){
         try{
-            const application = this.application.findAll({
+            const application = await this.application.findAll({
                 where:{application_id :applicationID}})
             return application
         }catch(error){

--- a/integration/UserDAO.js
+++ b/integration/UserDAO.js
@@ -1,9 +1,9 @@
-require('dotenv').config({path: `${process.cwd()}/../.env`});
-const { initModels } = require('../model/init-models');
-const cls = require('cls-hooked');
+require('dotenv').config({path: `${process.cwd()}/../.env`})
+const { initModels } = require('../model/init-models')
+const cls = require('cls-hooked')
 
 const databaseConfigPath = './config/database.js'
-const Sequelize = require ('sequelize');
+const Sequelize = require ('sequelize')
 
 /* 
 Class containing constructor for the DAO and its related methods pertaining to users. It is responsible for calls to the database.
@@ -20,24 +20,24 @@ class UserDAO {
         this.database = require(databaseConfigPath)
         const models = initModels(this.database)
         this.person = models.person
-    };
+    }
 
     /*
     Method used to confirm that a connection has been established
     */ 
     async connectToDB(){
         try {
-            await this.database.authenticate();
-            console.log('Connection has been established successfully.');
-            await this.database.models.role.sync();
-            await this.database.models.person.sync();
-            await this.database.models.competence.sync();
-            await this.database.models.competence_profile.sync();
-            await this.database.models.availability.sync();
-            await this.database.models.application.sync();
+            await this.database.authenticate()
+            console.log('Connection has been established successfully.')
+            await this.database.models.role.sync()
+            await this.database.models.person.sync()
+            await this.database.models.competence.sync()
+            await this.database.models.competence_profile.sync()
+            await this.database.models.availability.sync()
+            await this.database.models.application.sync()
         
         } catch (error) {
-            console.error('Unable to connect to the database:', error);
+            console.error('Unable to connect to the database:', error)
         }
     }
 
@@ -47,7 +47,7 @@ class UserDAO {
      * to directly interact with the database object through the constructor.
      */
     getDatabase(){
-        return this.database;
+        return this.database
     }
 
    /**
@@ -61,7 +61,7 @@ class UserDAO {
              const person = await this.person.findAll({
                 where: {username:username}
              })
-             return person;
+             return person
             }
             catch(err){
                 console.log("failed to find person", err)
@@ -76,7 +76,7 @@ class UserDAO {
     async findAllPersons(){
         try {
             const people = await this.person.findAll({limit:10}) //limit to 10 for now
-            return people;
+            return people
             
         } catch (error) {
             console.log("womp womp")
@@ -95,9 +95,9 @@ class UserDAO {
                 where:{person_id:ID}
             })
             if (person.length === 0) { //If there is no matching person, it will return an empty array.
-                    console.log(`Couldn't find user with ID ${ID}`); 
+                    console.log(`Couldn't find user with ID ${ID}`) 
             }
-            return person;
+            return person
         }
         catch(error){
             console.log("Error in findUserByID: ", error)
@@ -121,7 +121,7 @@ class UserDAO {
                 email : user.email,
                 role_id : user.role
                 })
-            return person;
+            return person
         }catch(error){
             console.debug("Couldn't create user" + error)
         }
@@ -145,4 +145,4 @@ class UserDAO {
 }
 
 
-module.exports = UserDAO;
+module.exports = UserDAO

--- a/integration/UserDAO.js
+++ b/integration/UserDAO.js
@@ -12,22 +12,18 @@ class UserDAO {
 
 /** 
  * Initializes the database based on the configurered sequelize instance from database.js
- * @param {string} env is used to initialize the testing database by having "test" as paramater
- * otherwise it defaults to the "regular" database
  */
-    constructor(env) {
-        const name = cls.createNamespace('iv1201-db');
-        Sequelize.useCLS(name);
-
-        env = process.env.NODE_ENV || "development";
+    constructor() {
+        const name = cls.createNamespace('iv1201-db')
+        Sequelize.useCLS(name)
 
         this.database = require(databaseConfigPath)
-        const models = initModels(this.database);
-        this.person = models.person;
+        const models = initModels(this.database)
+        this.person = models.person
     };
 
     /*
-    method used to confirm that a connection has been established
+    Method used to confirm that a connection has been established
     */ 
     async connectToDB(){
         try {
@@ -58,7 +54,7 @@ class UserDAO {
     * Method used to find a user in the person table based on their username.
     * 
     * @param {string} username: is the username used when logging in 
-    * @returns a json with the selected row in the person table
+    * @returns a JSON with the selected row in the person table
     */
     async findPersonByUsername(username){
         try{
@@ -75,7 +71,7 @@ class UserDAO {
     /**
      * Method used to find all people in the person table.
      * 
-     * @returns a json of the whole person table
+     * @returns a JSON of the whole person table
      */
     async findAllPersons(){
         try {
@@ -91,7 +87,7 @@ class UserDAO {
      * Method used to find a user in the person table based on their ID.
      * 
      * @param {number} ID: is used to match with the person_id in the person table 
-     * @returns a json with the selected row in the person table
+     * @returns a JSON with the selected row in the person table
      */
     async findUserById(ID){
         try{
@@ -108,8 +104,7 @@ class UserDAO {
         }
     }
 
-    /** WIP
-     * 
+    /** 
      * Method used to create a person in the person table.
      * 
      * @param {object} user: used to create  a user with different parameters 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "scripts": {
     "start:dev": "nodemon server.js",
-    "test": "jest"
+    "test": "jest --runInBand"
   }
 }

--- a/tests/applicationDAO.test.js
+++ b/tests/applicationDAO.test.js
@@ -1,28 +1,91 @@
-
-
-
-const UserDAO = require('../integration/UserDAO.js'); 
+const UserDAO = require('../integration/UserDAO.js')
 const ApplicationDAO = require('../integration/ApplicationDAO.js')
 
+const person1 = {
+    username:"abcdef", 
+    password:"fedcba", 
+    firstname:"John" , 
+    lastname:"Doe" , 
+    personalNumber : "00000420-1337", 
+    email : "john@finnsinte.se", 
+    role:2}
+
+const person2 = {
+    username:"JoeMama", 
+    password:"skrtskrt", 
+    firstname:"Joe" , 
+    lastname:"Mama" , 
+    personalNumber : "00000420-6969", 
+    email : "joe@finnsinte.se", 
+    role:2}
+
 describe('Application Database Integration Tests', () => {
-    let applicationDAO;
+    let applicationDAO
+    let userDAO
+
 
     beforeAll( () => {
-        applicationDAO = new ApplicationDAO("test")
-        applicationDAO.connectToDB();
-    });
-
-    beforeEach(async () => {
-        await applicationDAO.person.destroy({ truncate: true, cascade: true });
+        process.env.NODE_ENV = "test"
+        userDAO = new UserDAO()
+        applicationDAO = new ApplicationDAO()
     })
 
-    afterAll(async () => {
-        await applicationDAO.getDatabase().close();
+    beforeEach(async () => {
+        await applicationDAO.person.destroy({truncate: true, cascade: true})
+        await applicationDAO.application.destroy({truncate: true, cascade: true})
+
+    })
+
+    afterAll(async() => {
+        db = applicationDAO.getDatabase()
+        await db.close()
+        process.env.NODE_ENV = ""
     })
 
      test('should create an application',async () => {
-        const app = await applic.manageApplication(11, true)
-        expect(app).toBe(applic.getDatabase().models.application[0])
-       
-    }); 
-});
+        const user1 = await userDAO.createUser(person1)
+        const user2 = await userDAO.createUser(person2)
+
+        const app1 = await applicationDAO.createApplication(user1.person_id)
+        const app2 = await applicationDAO.createApplication(user2.person_id)
+        
+        await expect(app1).not.toBeNull()
+        await expect(app1.person_id).toBe(user1.person_id)
+        await expect(app2).not.toBeNull()
+        await expect(app2.person_id).toBe(user2.person_id)
+    })
+
+    test('should find an existing epplication', async() =>{
+        const user = await userDAO.createUser(person1)
+        const app = await applicationDAO.createApplication(user.person_id)
+        const foundApp = await applicationDAO.findApplicationByApplicationId(app.application_id)
+
+        await expect(foundApp).not.toBeNull()
+        await expect(app.application_id).toEqual(foundApp[0].application_id)
+        await expect(app.person_id).toEqual(foundApp[0].person_id)
+        await expect(app.application_status).toEqual(foundApp[0].application_status)
+    })
+
+    test('should alter an existing application', async ()=>{
+        const user = await userDAO.createUser(person1)
+        const appBeforeChange = await applicationDAO.createApplication(user.person_id)
+        
+        await expect(appBeforeChange).not.toBeNull()
+        await expect(appBeforeChange.application_status).toBe(null)
+
+        await applicationDAO.handleApplicationByPersonId(user.person_id, true)
+        const app = await applicationDAO.findApplicationByApplicationId(appBeforeChange.application_id)
+
+        await expect(app[0].application_status).not.toBe(appBeforeChange.application_status)
+        await expect(app[0].application_status).toEqual(true)
+    })
+
+    test('should delete an application from database', async() => {
+        const user = await userDAO.createUser(person1)
+        const app = await applicationDAO.createApplication(user.person_id)
+        await applicationDAO.deleteApplicationByApplicationId(app.application_id)
+        
+        const deleted = await applicationDAO.findApplicationByApplicationId(app.application_id)
+        await expect(deleted).toHaveLength(0)
+    })
+})

--- a/tests/applicationDAO.test.js
+++ b/tests/applicationDAO.test.js
@@ -73,9 +73,7 @@ describe('Application Database Integration Tests', () => {
         await expect(appBeforeChange).not.toBeNull()
         await expect(appBeforeChange.application_status).toBe(null)
 
-        await applicationDAO.handleApplicationByPersonId(user.person_id, true)
-        const app = await applicationDAO.findApplicationByApplicationId(appBeforeChange.application_id)
-
+        const app = await applicationDAO.handleApplicationByPersonId(user.person_id, true)
         await expect(app[0].application_status).not.toBe(appBeforeChange.application_status)
         await expect(app[0].application_status).toEqual(true)
     })

--- a/tests/userDAO.test.js
+++ b/tests/userDAO.test.js
@@ -1,4 +1,4 @@
-const UserDAO = require('../integration/UserDAO.js'); 
+const UserDAO = require('../integration/UserDAO.js')
 
 const person1 = {username:"abcdef", 
                 password:"fedcba", 
@@ -10,43 +10,48 @@ const person1 = {username:"abcdef",
 
 
 describe('UserDAO Database Integration Tests', () => {
-    let userDAO;
+    let userDAO
     beforeAll( () => {
-        userDAO = new  UserDAO("test")
-    });
+        process.env.NODE_ENV = "test"   //used to use an emtpy database with a similar structure to the "actual" database
+        userDAO = new UserDAO()
+    })
 
     beforeEach(async () => {
-        await userDAO.person.destroy({ truncate: true, cascade: true });
+        await userDAO.person.destroy({ truncate: true, cascade: true })
     })
 
     afterAll(async () => {
-        await userDAO.getDatabase().close();
+        const db = userDAO.getDatabase()
+        await db.close()
+        process.env.NODE_ENV = ""
     })
 
      test('should successfully connect to the database',async () => {
-        console.log = jest.fn(); // Capture console output
+        console.log = jest.fn() // Capture console output
         await userDAO.connectToDB()            
         await expect(console.log).toHaveBeenCalledWith("Connection has been established successfully.")
        
-    }); 
-
-    test('should successfully create and find user with id', async () => {
-        await userDAO.createUser({firstname:"banana"})
-        const user = await userDAO.findUserById(1);
-
-        expect(user).not.toBeNull();
-        expect(user[0].person_id).toBe(1)
     })
 
-    test('should successfully create and find user with a person object', async () => {
-        //await userDAO.createUser(person1)
-        await userDAO.createUser(person1);
-        console.debug(person1)
+    test('should successfully create user with name', async () => {
+        const user = await userDAO.createUser({username:"banana"})
 
-        const user = await userDAO.findUserById(1);
-        console.debug(user)
-
-        expect(user).not.toBeNull();
-        expect(user[0].person_id).toBe(1)
+        await expect(user).not.toBeNull()
+        await expect(user.username).toBe("banana")
     })
-});
+
+    test('should successfully create user with a person object', async () => {
+        const user = await userDAO.createUser(person1)
+
+        await expect(user).not.toBeNull()
+        await expect(user.name).toBe(person1.firstname)
+    })
+
+    test('should delete a user from the database', async() => {
+        const user = await userDAO.createUser(person1)
+        await userDAO.deleteUser(user.person_id)
+
+        const deleted = await userDAO.findUserById(user.person_id)
+        await expect(deleted).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
Added support for finding application by application ID. 

Removed the env parameter that was implemented for the constructer in both DAO files. The current implementation did not do anything (and it had to rightfully be changed because it overrided the variable for production). The purpose of setting the env variable in the constructor was to more easily get the test database. Instead, i change the node enviorement directly in my tests which works fine. 

Tests have been updated for tests pertaining to the user and tests have been added for application based methods. You can run them by running npm test in the commandline. Note that the tests assume an empty database with the exception of adding recruiter and applicant in the role table. This is because the role table is a foreign key for the person table, and in creating a user we need to set a role. This can be done by running the following in pgadmin after the tables have been created:

```
INSERT INTO public.role (role_id, name) 
VALUES 
    (1, 'recruiter'),
    (2, 'applicant');

```
I will check later if i can automate this into the tests. 

Updated some comments and removed semi colons